### PR TITLE
Curlfetch

### DIFF
--- a/findcurl.cmd
+++ b/findcurl.cmd
@@ -1,0 +1,27 @@
+@echo off
+rem This script breaks when the version gets updated.
+rem Can someone else work a way around that?
+rem This script does not handle failure to make a directory
+rem nor a failure to download the curl.cab
+rem It also assumes that curl is downloaded to the users Desktop
+
+set DLPAGE=http://skanthak.homepage.t-online.de/download
+set CURLVERSION=curl-7.64.1.cab
+set LINK=%DLPAGE%/%CURLVERSION%
+rem Check if curl exists
+echo Fetching %LINK%
+
+curl --version 2>NUL 1>&2
+
+if %ERRORLEVEL == 9009 (
+    mkdir internal\curl >NUL
+    explorer %LINK%
+rem we should wait until the file is downloaded, because explorer returns straight away
+    "%SystemRoot%\system32\expand.exe" "%USERPROFILE%\Desktop\%CURLVERSION%" /F:* internal\curl
+
+    rem Add to path
+    PATH=%PATH%;%~dp0\internal\curl
+) ELSE (
+    echo "Found curl, continuing"
+)
+

--- a/findcurl.cmd
+++ b/findcurl.cmd
@@ -9,12 +9,12 @@ set DLPAGE=http://skanthak.homepage.t-online.de/download
 set CURLVERSION=curl-7.64.1.cab
 set LINK=%DLPAGE%/%CURLVERSION%
 rem Check if curl exists
-echo Fetching %LINK%
 
 curl --version 2>NUL 1>&2
 
 if %ERRORLEVEL == 9009 (
     mkdir internal\curl >NUL
+    echo Fetching %LINK%
     explorer %LINK%
 rem we should wait until the file is downloaded, because explorer returns straight away
     "%SystemRoot%\system32\expand.exe" "%USERPROFILE%\Desktop\%CURLVERSION%" /F:* internal\curl

--- a/findcurl.cmd
+++ b/findcurl.cmd
@@ -8,17 +8,17 @@ rem It also assumes that curl is downloaded to the users Desktop
 set DLPAGE=http://skanthak.homepage.t-online.de/download
 set CURLVERSION=curl-7.64.1.cab
 set LINK=%DLPAGE%/%CURLVERSION%
-rem Check if curl exists
+rem grab the arch. We'll need this to extract files.
+reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" > NUL && set ARCH=i386|| set ARCH=amd64
 
+rem Check if curl exists
 curl --version 2>NUL 1>&2
+
 
 if %ERRORLEVEL == 9009 (
     mkdir internal\curl >NUL
     echo Fetching %LINK%
     explorer %LINK%
-
-    rem grab the arch. We'll need this to extract files.
-    reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" > NUL && set ARCH=i386|| set ARCH=amd64
 
     rem we should wait until the file is downloaded, because explorer returns straight away
     "%SystemRoot%\system32\expand.exe" "%USERPROFILE%\Desktop\%CURLVERSION%" /F:%ARCH%\* internal\curl
@@ -28,4 +28,3 @@ if %ERRORLEVEL == 9009 (
 ) ELSE (
     echo "Found curl, continuing"
 )
-

--- a/findcurl.cmd
+++ b/findcurl.cmd
@@ -16,8 +16,12 @@ if %ERRORLEVEL == 9009 (
     mkdir internal\curl >NUL
     echo Fetching %LINK%
     explorer %LINK%
-rem we should wait until the file is downloaded, because explorer returns straight away
-    "%SystemRoot%\system32\expand.exe" "%USERPROFILE%\Desktop\%CURLVERSION%" /F:* internal\curl
+
+    rem grab the arch. We'll need this to extract files.
+    reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" > NUL && set ARCH=i386|| set ARCH=amd64
+
+    rem we should wait until the file is downloaded, because explorer returns straight away
+    "%SystemRoot%\system32\expand.exe" "%USERPROFILE%\Desktop\%CURLVERSION%" /F:%ARCH%\* internal\curl
 
     rem Add to path
     PATH=%PATH%;%~dp0\internal\curl


### PR DESCRIPTION
This is a preliminary script to handle fetching a recent curl cab file if the user doesn't have curl on their system. It should be applicable for all versions of Windows from XP up to 8.1 (or maybe even really really early Windows 10 that haven't been updated.)

Current problems with it are:
* It doesn't track changes in curl version. I haven't figured out how to update this script in the event that the origin changes the available version of curl.
* It fails to wait until the file is downloaded before heading off to the next step.
* it doesn't clean up after itself, so the curl cab is left on the desktop. This might work either way.
* It's not called from the main script yet. This should be an easy patch to setup_win.cmd

So, if someone else can find out how to get the script to wait until the file's completely downloaded before it tries extracting the components, I'll be grateful. 

