### PR TITLE
correcting choice usage

### DIFF
--- a/setup_win.cmd
+++ b/setup_win.cmd
@@ -56,7 +56,7 @@ reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" 
 
 :choose
 choice /c 12 /M "Use (1) 64-bit or (2) 32-bit MINGW? "
-if errlevel == 1 goto chose64
+if errorlevel == 1 goto chose64
 goto chose32
 
 :chose32


### PR DESCRIPTION
The choice command reports to the environment variable ERRORLEVEL, not to errlevel.

Signed-off-by: Brickviking <brickviking@gmail.com>