### PR TITLE
Fix for missing choice.exe on XP

### DIFF
--- a/findcurl.cmd
+++ b/findcurl.cmd
@@ -16,13 +16,17 @@ curl --version 2>NUL 1>&2
 
 
 if %ERRORLEVEL == 9009 (
+rem check if we have it already
+    if exist internal\curl\curl.exe goto gotcurl
     mkdir internal\curl >NUL
     echo Fetching %LINK%
     explorer %LINK%
-
     rem we should wait until the file is downloaded, because explorer returns straight away
+:keeptesting
+    rem sleep 5 - we need to find something that'll work on XP, as timeout doesn't exist
+    rem if not exist "%USERPROFILE%\Desktop\%CURLVERSION%" goto keeptesting
     "%SystemRoot%\system32\expand.exe" "%USERPROFILE%\Desktop\%CURLVERSION%" /F:%ARCH%\* internal\curl
-
+:gotcurl
     rem Add to path
     PATH=%PATH%;%~dp0\internal\curl
 ) ELSE (

--- a/findcurl.cmd
+++ b/findcurl.cmd
@@ -15,7 +15,7 @@ rem Check if curl exists
 curl --version 2>NUL 1>&2
 
 
-if %ERRORLEVEL == 9009 (
+if %ERRORLEVEL% == 9009 (
 rem check if we have it already
     if exist internal\curl\curl.exe goto gotcurl
     mkdir internal\curl >NUL

--- a/setup_win.cmd
+++ b/setup_win.cmd
@@ -84,7 +84,13 @@ echo Testing for 7zip
 if ERRORLEVEL 9009 (
 
     echo Downloading 7zr.exe...
-    curl -L https://www.7-zip.org/a/7zr.exe -o 7zr.exe
+	rem Check for XP (either 32-bit or 64-bit)
+	ver | findstr /R /C:"Version 5.[12]"
+	if errorlevel 0 (
+        curl -Lk https://www.7-zip.org/a/7zr.exe -o 7zr.exe
+    ) else (
+        curl -L https://www.7-zip.org/a/7zr.exe -o 7zr.exe
+	)
 
     echo Extracting C++ Compiler...
     7zr.exe x temp.7z -y

--- a/setup_win.cmd
+++ b/setup_win.cmd
@@ -55,8 +55,12 @@ rem )
 reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" > NUL && goto chose32 || goto choose
 
 :choose
-choice /c 12 /M "Use (1) 64-bit or (2) 32-bit MINGW? "
-if errorlevel == 1 goto chose64
+if not exist %SystemRoot%\system32\choice.exe (
+    set /p errorlevel="Use (1) 64-bit or (2) 32-bit MINGW? "
+) else (
+    choice /c 12 /M "Use (1) 64-bit or (2) 32-bit MINGW? "
+)
+if errorlevel 1 goto chose64
 goto chose32
 
 :chose32

--- a/setup_win.cmd
+++ b/setup_win.cmd
@@ -56,9 +56,9 @@ reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" 
 
 :choose
 if not exist %SystemRoot%\system32\choice.exe (
-    set /p errorlevel="Use (1) 64-bit or (2) 32-bit MINGW? "
+    set /p errorlevel="Install (1) 64-bit or (2) 32-bit MINGW? "
 ) else (
-    choice /c 12 /M "Use (1) 64-bit or (2) 32-bit MINGW? "
+    choice /c 12 /M "Download (1) 64-bit or (2) 32-bit MINGW? "
 )
 if errorlevel 1 goto chose64
 goto chose32

--- a/setup_win.cmd
+++ b/setup_win.cmd
@@ -78,18 +78,28 @@ goto chosen
 echo Downloading %url%...
 curl -L %url% -o temp.7z
 
-echo Downloading 7zr.exe...
-curl -L https://www.7-zip.org/a/7zr.exe -o 7zr.exe
+echo Testing for 7zip
+7z >NUL 2>&1
 
-echo Extracting C++ Compiler...
-7zr.exe x temp.7z -y
+if ERRORLEVEL 9009 (
+
+    echo Downloading 7zr.exe...
+    curl -L https://www.7-zip.org/a/7zr.exe -o 7zr.exe
+
+    echo Extracting C++ Compiler...
+    7zr.exe x temp.7z -y
+) else (
+    echo Extracting C++ Compiler...
+    7z x temp.7z -y
+)
 
 echo Moving C++ compiler...
 for /f %%a in ('dir %MINGW% /b') do move /y "%MINGW%\%%a" internal\c\c_compiler\
 
 echo Cleaning up..
 rd %MINGW%
-del 7zr.exe
+if exist 7zr.exe del 7zr.exe
+
 del temp.7z
 
 :skipccompsetup

--- a/setup_win.cmd
+++ b/setup_win.cmd
@@ -58,7 +58,7 @@ reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" 
 if not exist %SystemRoot%\system32\choice.exe (
     set /p errorlevel="Install (1) 64-bit or (2) 32-bit MINGW? "
 ) else (
-    choice /c 12 /M "Download (1) 64-bit or (2) 32-bit MINGW? "
+    choice /c 12 /M "Install (1) 64-bit or (2) 32-bit MINGW? "
 )
 if errorlevel 1 goto chose64
 goto chose32


### PR DESCRIPTION
Two changes here, one to work around the missing `CHOICE.EXE` command on XP, the other to prepare for a possible "wait until file downloads before we unarchive it" change.

I'm after some help here, is there a way of platform-independently waiting for a set amount of time on Windows XP? So far the only options I've seen for waiting have used `timeout`, which doesn't exist on XP, or ping, which is ugly, but does work as long as the machine has networking up. I only really need it to fetch the initial curl cab file by using Internet Explorer to download the file, as every version from 10 onwards appears to have curl.exe already installed as part of the base operating system files.