### PR TITLE
Reverting previous change to type2symbol$(); see description.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
     "makefile.extensionOutputFolder": "./.vscode",
     "files.associations": {
         "src.c": "cpp"
-    }
+    },
+    "editor.multiCursorModifier": "ctrlCmd"
 }

--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -6251,7 +6251,7 @@ FUNCTION ide2 (ignore)
                 GOSUB redrawItAll: GOTO ideloop
             END IF
 
-            IF menu$(m, s) = "#Save  Ctrl+S" THEN
+            IF menu$(m, s) = "#Save  Ctrl+S" THEN '"#Save  Ctrl+S" THEN
                 PCOPY 2, 0
                 IF ideprogname = "" THEN
                     ProposedTitle$ = FindProposedTitle$
@@ -18126,15 +18126,36 @@ END FUNCTION
 
 SUB IdeMakeFileMenu
     m = 1: i = 0
-    menu$(m, i) = "File": i = i + 1
-    menu$(m, i) = "#New  Ctrl+N": i = i + 1
-    menuDesc$(m, i - 1) = "Closes current program and starts a blank one"
-    menu$(m, i) = "#Open...  Ctrl+O": i = i + 1
-    menuDesc$(m, i - 1) = "Loads a program into memory"
-    menu$(m, i) = "#Save  Ctrl+S": i = i + 1
-    menuDesc$(m, i - 1) = "Writes current program to a file on disk"
-    menu$(m, i) = "Save #As...": i = i + 1
-    menuDesc$(m, i - 1) = "Saves current program with specified name"
+    IF 1=1 THEN
+        menu$(m, i) = "File": i = i + 1
+        menu$(m, i) = "#New  Ctrl+N": i = i + 1
+        menuDesc$(m, i - 1) = "Closes current program and starts a blank one"
+        menu$(m, i) = "#Open...  Ctrl+O": i = i + 1
+        menuDesc$(m, i - 1) = "Loads a program into memory"
+        menu$(m, i) = "#Save  Ctrl+S": i = i + 1
+        menuDesc$(m, i - 1) = "Writes current program to a file on disk"
+        menu$(m, i) = "Save #As...": i = i + 1
+        menuDesc$(m, i - 1) = "Saves current program with specified name"
+    ELSE
+        menu$(m, i) = "File": i = i + 1
+        menu$(m, i) = "#New Program  Ctrl+N": i = i + 1 '"#New  Ctrl+N"
+        menuDesc$(m, i - 1) = "Removes currently loaded program from memory"
+        menu$(m, i) = "#Open Program...  Ctrl+O": i = i + 1 '"#Open...  Ctrl+O"
+        menuDesc$(m, i - 1) = "Loads new program into memory"
+        menu$(m, i) = "~#Merge...": i = i + 1
+        menuDesc$(m, i - 1) = "Inserts specified file into current module"
+        menu$(m, i) = "#Save  Ctrl+S": i = i + 1 '"#Save  Ctrl+S"
+        menuDesc$(m, i - 1) = "Writes current module to file on disk"
+        menu$(m, i) = "Save #As...": i = i + 1
+        menuDesc$(m, i - 1) = "Saves current module with specified name and format"
+        menu$(m, i) = "~Sa#ve All": i = i + 1
+        menuDesc$(m, i - 1) = "Writes all currently loaded modules to files on disk"
+        menu$(m, i) = "-": i = i + 1
+        menu$(m, i) = "~#Print...": i = i + 1
+        menuDesc$(m, i - 1) = "Prints specified text or module"
+        menu$(m, i) = "~#DOS Shell...": i = i + 1
+        menuDesc$(m, i - 1) = "Invokes DOS shell"
+    END IF
     fh = FREEFILE
     OPEN ".\internal\temp\recent.bin" FOR BINARY AS #fh: a$ = SPACE$(LOF(fh)): GET #fh, , a$
     a$ = RIGHT$(a$, LEN(a$) - 2)
@@ -18167,6 +18188,7 @@ SUB IdeMakeFileMenu
     NEXT
     CLOSE #fh
     IF menu$(m, i - 1) <> "#Recent..." AND menu$(m, i - 1) <> "Save #As..." THEN
+        menu$(m, i) = "-": i = i + 1
         menu$(m, i) = "#Clear Recent...": i = i + 1
         menuDesc$(m, i - 1) = "Clears list of recently loaded files"
     ELSE

--- a/source/qb64.bas
+++ b/source/qb64.bas
@@ -22628,41 +22628,41 @@ FUNCTION type2symbol$ (typ$)
         IF MID$(t$, i, 1) = sp THEN MID$(t$, i, 1) = " "
     NEXT
     e$ = "Cannot convert type (" + typ$ + ") to symbol"
-    t2$ = "_UNSIGNED _BIT": s$ = "~`1": IF t$ = t2$ THEN GOTO t2sfound
-    t2$ = "_UNSIGNED _BYTE": s$ = "~%%": IF t$ = t2$ THEN GOTO t2sfound
-    t2$ = "_UNSIGNED LONG": s$ = "~&": IF t$ = t2$ THEN GOTO t2sfound
-    t2$ = "_UNSIGNED _INTEGER64": s$ = "~&&": IF t$ = t2$ THEN GOTO t2sfound
-    t2$ = "_UNSIGNED INTEGER": s$ = "~%": IF t$ = t2$ THEN GOTO t2sfound
-    t2$ = "_UNSIGNED _OFFSET": s$ = "~%&": IF t$ = t2$ THEN GOTO t2sfound
-    t2$ = "_BIT": s$ = "`1": IF t$ = t2$ THEN GOTO t2sfound
-    t2$ = "_BYTE": s$ = "%%": IF t$ = t2$ THEN GOTO t2sfound
-    t2$ = "LONG": s$ = "&": IF t$ = t2$ THEN GOTO t2sfound
-    t2$ = "_INTEGER64": s$ = "&&": IF t$ = t2$ THEN GOTO t2sfound
-    t2$ = "_OFFSET": s$ = "%&": IF t$ = t2$ THEN GOTO t2sfound
-    t2$ = "SINGLE": s$ = "!": IF t$ = t2$ THEN GOTO t2sfound
-    t2$ = "DOUBLE": s$ = "#": IF t$ = t2$ THEN GOTO t2sfound
-    t2$ = "_FLOAT": s$ = "##": IF t$ = t2$ THEN GOTO t2sfound
-    t2$ = "STRING": s$ = "$": IF t$ = t2$ THEN GOTO t2sfound
-    t2$ = "UNSIGNED BIT": s$ = "~`1": IF qb64prefix_set = 1 AND t$ = t2$ THEN GOTO t2sfound
-    t2$ = "UNSIGNED BYTE": s$ = "~%%": IF qb64prefix_set = 1 AND t$ = t2$ THEN GOTO t2sfound
-    t2$ = "UNSIGNED LONG": s$ = "~&": IF qb64prefix_set = 1 AND t$ = t2$ THEN GOTO t2sfound
-    t2$ = "UNSIGNED INTEGER64": s$ = "~&&": IF qb64prefix_set = 1 AND t$ = t2$ THEN GOTO t2sfound
-    t2$ = "UNSIGNED INTEGER": s$ = "~%": IF qb64prefix_set = 1 AND t$ = t2$ THEN GOTO t2sfound
-    t2$ = "UNSIGNED OFFSET": s$ = "~%&": IF qb64prefix_set = 1 AND t$ = t2$ THEN GOTO t2sfound
-    t2$ = "UNSIGNED _BIT": s$ = "~`1": IF qb64prefix_set = 1 AND t$ = t2$ THEN GOTO t2sfound
-    t2$ = "UNSIGNED _BYTE": s$ = "~%%": IF qb64prefix_set = 1 AND t$ = t2$ THEN GOTO t2sfound
-    t2$ = "UNSIGNED _INTEGER64": s$ = "~&&": IF qb64prefix_set = 1 AND t$ = t2$ THEN GOTO t2sfound
-    t2$ = "UNSIGNED _OFFSET": s$ = "~%&": IF qb64prefix_set = 1 AND t$ = t2$ THEN GOTO t2sfound
-    t2$ = "_UNSIGNED BIT": s$ = "~`1": IF qb64prefix_set = 1 AND t$ = t2$ THEN GOTO t2sfound
-    t2$ = "_UNSIGNED BYTE": s$ = "~%%": IF qb64prefix_set = 1 AND t$ = t2$ THEN GOTO t2sfound
-    t2$ = "_UNSIGNED INTEGER64": s$ = "~&&": IF qb64prefix_set = 1 AND t$ = t2$ THEN GOTO t2sfound
-    t2$ = "_UNSIGNED OFFSET": s$ = "~%&": IF qb64prefix_set = 1 AND t$ = t2$ THEN GOTO t2sfound
-    t2$ = "BIT": s$ = "`1": IF qb64prefix_set = 1 AND t$ = t2$ THEN GOTO t2sfound
-    t2$ = "BYTE": s$ = "%%": IF qb64prefix_set = 1 AND t$ = t2$ THEN GOTO t2sfound
-    t2$ = "INTEGER64": s$ = "&&": IF qb64prefix_set = 1 AND t$ = t2$ THEN GOTO t2sfound
-    t2$ = "INTEGER": s$ = "%": IF t$ = t2$ THEN GOTO t2sfound
-    t2$ = "OFFSET": s$ = "%&": IF qb64prefix_set = 1 AND t$ = t2$ THEN GOTO t2sfound
-    t2$ = "FLOAT": s$ = "##": IF qb64prefix_set = 1 AND t$ = t2$ THEN GOTO t2sfound
+    t2$ = "_UNSIGNED _BIT": s$ = "~`1": IF LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "_UNSIGNED _BYTE": s$ = "~%%": IF LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "_UNSIGNED LONG": s$ = "~&": IF LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "_UNSIGNED _INTEGER64": s$ = "~&&": IF LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "_UNSIGNED INTEGER": s$ = "~%": IF LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "_UNSIGNED _OFFSET": s$ = "~%&": IF LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "_BIT": s$ = "`1": IF LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "_BYTE": s$ = "%%": IF LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "LONG": s$ = "&": IF LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "_INTEGER64": s$ = "&&": IF LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "_OFFSET": s$ = "%&": IF LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "SINGLE": s$ = "!": IF LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "DOUBLE": s$ = "#": IF LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "_FLOAT": s$ = "##": IF LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "STRING": s$ = "$": IF LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "UNSIGNED BIT": s$ = "~`1": IF qb64prefix_set = 1 AND LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "UNSIGNED BYTE": s$ = "~%%": IF qb64prefix_set = 1 AND LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "UNSIGNED LONG": s$ = "~&": IF qb64prefix_set = 1 AND LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "UNSIGNED INTEGER64": s$ = "~&&": IF qb64prefix_set = 1 AND LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "UNSIGNED INTEGER": s$ = "~%": IF qb64prefix_set = 1 AND LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "UNSIGNED OFFSET": s$ = "~%&": IF qb64prefix_set = 1 AND LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "UNSIGNED _BIT": s$ = "~`1": IF qb64prefix_set = 1 AND LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "UNSIGNED _BYTE": s$ = "~%%": IF qb64prefix_set = 1 AND LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "UNSIGNED _INTEGER64": s$ = "~&&": IF qb64prefix_set = 1 AND LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "UNSIGNED _OFFSET": s$ = "~%&": IF qb64prefix_set = 1 AND LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "_UNSIGNED BIT": s$ = "~`1": IF qb64prefix_set = 1 AND LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "_UNSIGNED BYTE": s$ = "~%%": IF qb64prefix_set = 1 AND LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "_UNSIGNED INTEGER64": s$ = "~&&": IF qb64prefix_set = 1 AND LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "_UNSIGNED OFFSET": s$ = "~%&": IF qb64prefix_set = 1 AND LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "BIT": s$ = "`1": IF qb64prefix_set = 1 AND LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "BYTE": s$ = "%%": IF qb64prefix_set = 1 AND LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "INTEGER64": s$ = "&&": IF qb64prefix_set = 1 AND LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "INTEGER": s$ = "%": IF LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "OFFSET": s$ = "%&": IF qb64prefix_set = 1 AND LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
+    t2$ = "FLOAT": s$ = "##": IF qb64prefix_set = 1 AND LEFT$(t$, LEN(t2$)) = t2$ THEN GOTO t2sfound
     Give_Error e$: EXIT FUNCTION
     t2sfound:
     type2symbol$ = s$


### PR DESCRIPTION
There was a change made in v2.0.3? that appears to break the following valid code:

```vb
Function test ()
    Static a(10) As String * 2
End Function
```

There doesn't appear to be much in the summary/description of the original change as to what it was supposed to resolve; so reversing the change(s).  See https://github.com/DualBrain/qb64-development/commit/b87dde8d896aa636b8d825241c094b3b1ea3fca9 for details on the original commit that is being reverted.

Also includes minor (not currently active) placeholder code for updated File menu.