### PR TITLE
OS X clang standard set to C++11

### DIFF
--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -145,6 +145,7 @@ void setbits(uint32 bsize,uint8 *base,ptrszint i,int64 val){
 #ifdef QB64_UNIX
     #include <pthread.h>
     #include <libgen.h> //required for dirname()
+    #include <sys/ioctl.h> //required for terminal width and height
 #endif
 
 #ifdef QB64_LINUX
@@ -19084,6 +19085,13 @@ void sub_put2(int32 i,int64 offset,void *element,int32 passed){
                     return cl_bufinfo.srWindow.Right - cl_bufinfo.srWindow.Left + 1;
                 }
             #endif
+            #ifdef QB64_UNIX
+                if ((read_page->console && !passed)||i==console_image){
+                    struct winsize w;
+                    ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
+                    return w.ws_col;
+                }
+            #endif
 
             if (passed){
                 if (i>=0){//validate i
@@ -19112,6 +19120,13 @@ void sub_put2(int32 i,int64 offset,void *element,int32 passed){
                     GetConsoleScreenBufferInfo(cl_conout, &cl_bufinfo);
                     return cl_bufinfo.srWindow.Bottom - cl_bufinfo.srWindow.Top + 1;
                     return cl_bufinfo.dwMaximumWindowSize.Y;
+                }
+            #endif
+            #ifdef QB64_UNIX
+                if ((read_page->console && !passed)||i==console_image){
+                    struct winsize w;
+                    ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
+                    return w.ws_row;
                 }
             #endif
 

--- a/internal/c/libqb/os/osx/setup_build.command
+++ b/internal/c/libqb/os/osx/setup_build.command
@@ -1,3 +1,2 @@
 cd "$(dirname "$0")"
-clang++ -c -w -Wall ../../../libqb.mm -D DEPENDENCY_LOADFONT -o libqb_setup.o
-
+clang++ -c -std=c++11 -w -Wall ../../../libqb.mm -D DEPENDENCY_LOADFONT -o libqb_setup.o


### PR DESCRIPTION
This was done to support C++11 like initializations as used in libqb. 

Signed-off-by: Christoph Hahn <chrhhn@gmail.com>