### PR TITLE
PPC64 Debian fixes

### DIFF
--- a/internal/c/makedat_lnx32.txt
+++ b/internal/c/makedat_lnx32.txt
@@ -1,1 +1,0 @@
-objcopy -Ibinary -Oelf32-i386 -Bi386

--- a/internal/c/makedat_lnx64.txt
+++ b/internal/c/makedat_lnx64.txt
@@ -1,3 +1,0 @@
-objcopy -Ibinary -Oelf64-x86-64 -Bi386:x86-64
-
-

--- a/internal/c/os.h
+++ b/internal/c/os.h
@@ -34,7 +34,7 @@
     #error "Unknown system; refusing to build. Edit os.h if needed"
 #endif
 
-#if defined(_WIN64) || defined(__x86_64__) || defined(__ppc64__) || defined(QB64_MACOSX) || defined(__aarch64__)
+#if defined(_WIN64) || defined(__x86_64__) || defined(__ppc64__) || defined(__PPC64__) || defined(QB64_MACOSX) || defined(__aarch64__)
     #define QB64_64
     #else
     #define QB64_32


### PR DESCRIPTION
This patch set gets QB64 working on ppc64le Debian.

The first patch checks for the uppercase __PPC64__ macro.

The second patch changes the method by which objcopy arguments are generated.  Instead of hard-coding them in text files, they are read from the default linker script, printed by "ld --verbose".

The new approach should be portable to other GNU/Linux systems and architectures as well.

I tested the patches on x86-64 the work there too.  I don't have a 32-bit environment in which to test.  Does continuous integration cover that?